### PR TITLE
fix: ReplaySubject synchronous reentrant values

### DIFF
--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -403,4 +403,26 @@ describe('ReplaySubject', () => {
     // results is [7] ?? wat?
     expect(results).to.deep.equal([1, 2, 3, 4]);
   });
+
+  it('should replay reentrant errors after emitting all values', () => {
+    const subject = new ReplaySubject<number>();
+    subject.next(1);
+    subject.next(2);
+
+    const results: string[] = [];
+
+    subject.subscribe(
+      (value) => {
+        results.push(value.toString());
+        if (value === 1) {
+          subject.error(new Error('error'));
+        }
+      },
+      (error) => {
+        results.push(error.message);
+      }
+    );
+
+    expect(results).to.deep.equal(['1', '2', 'error']);
+  });
 });

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -79,11 +79,9 @@ export class ReplaySubject<T> extends Subject<T> {
       next(value) {
         syncValues.push(value);
       },
-      error(e) {
-        subscriber.error(e);
-      },
-      complete() {
-        subscriber.complete();
+      error() {
+        // syncSubscriber needs error() to be defined, otherwise errors will be raised as uncaught.
+        // In that case, `super` keeps the error that happened, and will emit it on _checkFinalizedStatuses.
       },
     });
     subscriber.add(syncSubscriber);


### PR DESCRIPTION
The tests you added in https://github.com/ReactiveX/rxjs/pull/6930 were really interesting, I gave it a go and came up with this. Probably needs approval from one of the RxJS core team.

The problem was that when ReplaySubject replayed all the values to a new subscriber, new emissions would hit the subscriber directly instead of being pushed afterwards.

My first take was to first emit every value and then subscribe to the actual subject, and this would make the new tests pass but it failed on another that tests specifically this (`should add the observer before running subscription code`). And it makes sense because if you don't do a `take(_)`, then you want those values to come through as well.

This solution then keeps the subscribe before emitting values, but protects the subscriber in a way that if new values come through as it's emitting them, it just pushes them to the local copy, so that they will get emitted in sequence.

But it leaves some questions open... what if it completes? what if it errors? Currently I synchronously send the complete/error whenever it happens, but it could be argued that first all the values should be completely emitted before complete/error. I left it like this because I think that delay() has a similar behaviour too.